### PR TITLE
月毎の収支データ取得追加

### DIFF
--- a/app/controllers/api/v1/calculated_monthly_transactions_controller.rb
+++ b/app/controllers/api/v1/calculated_monthly_transactions_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::CalculatedMonthlyTransactionsController < ActionController::API
+  def index
+    calculated_monthly_transactions = CalculatedMonthlyTransaction.all
+    render json: calculated_monthly_transactions, status: :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
           delete :destroy_multiple
         end
       end
+
+      resources :calculated_monthly_transactions, only: [ :index ]
     end
   end
 

--- a/spec/requests/calculated_monthly_transactions_request_spec.rb
+++ b/spec/requests/calculated_monthly_transactions_request_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'CalculatedMonthlyTransactions API', type: :request do
+  before do
+    CalculatedMonthlyTransaction.delete_all
+  end
+
+  describe 'GET /index' do
+    let(:user) { create(:user) }
+    let(:category) { create(:category) }
+    let(:transaction_params) do
+      {
+        transaction: {
+          amount: 1000,
+          date: '2025-01-01',
+          description: 'テスト',
+          transaction_type: 'expense',
+          user_id: user.id,
+          category_id: category.id
+        }
+      }
+    end
+
+    def send_get_request
+      get "#{@base_url}/api/v1/calculated_monthly_transactions"
+    end
+
+    def send_transaction_post_request(params)
+      post "#{@base_url}/api/v1/transactions", params: params
+    end
+
+    it 'return a 200 status code' do
+      send_get_request
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'return all calculated monthly transactions in JSON format' do
+      send_transaction_post_request(transaction_params)
+      send_get_request
+      json = JSON.parse(response.body)
+      expect(json.size).to eq(1)
+    end
+  end
+end

--- a/spec/services/delete_transactions_service_spec.rb
+++ b/spec/services/delete_transactions_service_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-# require_relative '../../app/services/except_monthly_transaction_service'
 
 RSpec.describe DeleteTransactionsService, type: :service do
   before do


### PR DESCRIPTION
## 概要
月毎の収支データを取得するアクションを追加

## 背景
フロントで月毎の収支を円グラフとして表示できるように、CalculatedMonthlyTransactionsのデータを取得するアクションを追加する。

- calculated_monthly_transactions_controller.rbを追加し、indexアクションを追加
- route.rbにルーティングを追加

## テスト
calculated_monthly_transactions_request_spec.rbを作成し、indexアクションのテストを追加

## 関連
https://github.com/kobayashi0201/kakeibo_frontend/pull/6